### PR TITLE
gtpsp Getting Started

### DIFF
--- a/docs/psp/getting_started.md
+++ b/docs/psp/getting_started.md
@@ -51,13 +51,21 @@ You can also run the game unpacked which may help for modding faster. **NOTE: Th
 
 !!! warning
 
-    This is currently limited to GTPSP EU 2.00. Feel free to port the patch to other regions.
+    This is currently limited to listed version of GTPSP. Feel free to port the patch to other regions.
 
 Requirements:
 
 * Game is registered as a folder game rather than iso.
 * Proper file structure as shown below. Volume contents must be extracted directly at the root.
-* [Patch](patches/UCES01245.ini) (currently GTPSP EU 2.00 only). **Right-click save to**
+!!! abstract "Patch"
+
+    **Right-click save to**
+
+    ??? abstract "UCES01245"
+        [Patch EU(2.00)](patches/UCES01245.ini)
+
+    ??? abstract "UCJS10100"
+        [Patch JP(1.01)](patches/UCJS10100.ini)
 
 Once that is done:
 

--- a/docs/psp/getting_started.md
+++ b/docs/psp/getting_started.md
@@ -19,7 +19,7 @@ These pages currently cover **GT PSP**.
 
 GT PSP uses the [volume system](../concepts/volume.md), which will need to be extracted in order to gain access to game contents.
 
-If you haven't already, extract the `.iso` file using [7-Zip](https://www.7-zip.org/) or by any other means. You should be able to see a `GT3.VOL` file.
+If you haven't already, extract the `.iso` file using [7-Zip](https://www.7-zip.org/) or by any other means. You should be able to see a `GT.VOL` file.
 
 Using `GTPSPVolTools`, unpack the volume file as such
 
@@ -82,14 +82,31 @@ Once that is done:
     ```{ .sh .no-copy }
     .
     ├─ GTPSP/  # This is the game folder.
-       ├─ PRX/ # < Copy the folder from PSP_GAME/USRDIR/PRX!
        ├─ advertise/
        ├─ car/
-       ├─ ...
+       ├─ carsound/
+       ├─ character/
+       ├─ crs/
+       ├─ description/
+       ├─ font/
+       ├─ icon/
+       ├─ movie/
+       ├─ piece_gt5m/
+       ├─ products/
+       ├─ projects/
+       ├─ PRX/ # < Copy "PSP_GAME/USRDIR/MODULE" from GTPSP ISO.
+       |   ├─LIBFONT.PRX
+       |   ├─LIBSUPPREACC.PRX
+       |   └─PSMF.PRX
        ├─ PSP_GAME/
        |  └─ ...
+       ├─ replay/
+       ├─ scripts/
+       ├─ sound_gt/
+       ├─ specdb/
+       ├─ textdata/
+       ├─ wheel/
        └─ UMD_DATA.BIN
-    ...
     ```
 
 !!! abstract "How does it work?"

--- a/docs/psp/patches/UCES01245.ini
+++ b/docs/psp/patches/UCES01245.ini
@@ -4,7 +4,7 @@ _S UCES-01245
 // By Nenkai
 // https://nenkai.github.io/gt-modding-hub/psp/getting_started/
 
-_C1 Load Files Unpacked
+_C1 Load Files Unpacked [for 2.00]
 // NOTE TO SELF:
 // Of course NOTHING mentioned that the addresses are relative to module
 // Rather than absolute.. so you have to subtract 0x8800000 from ghidra/ppsspp debugger.

--- a/docs/psp/patches/UCJS10100.ini
+++ b/docs/psp/patches/UCJS10100.ini
@@ -1,13 +1,12 @@
-// JP ver 1.0.1.4625568
 _S UCJS-10100
 
-// By Nenkai
+// By Nenkai,chmcl95
 // https://nenkai.github.io/gt-modding-hub/psp/getting_started/
 
-_C1 Load Files Unpacked
-//// NOTE TO SELF:
-//// Of course NOTHING mentioned that the addresses are relative to module
-//// Rather than absolute.. so you have to subtract 0x8800000 from ghidra/ppsspp debugger.
+_C1 Load Files Unpacked [for 1.01]
+// NOTE TO SELF:
+// Of course NOTHING mentioned that the addresses are relative to module
+// Rather than absolute.. so you have to subtract 0x8800000 from ghidra/ppsspp debugger.
 
 // ms0:/ -> disc0:/
 _L 0x20497434 0x63736964


### PR DESCRIPTION
- fix VOL file name
"GT3.VOL" -> "GT.VOL".

- setup folder structure
listing all folder names under GTPSP folder.
fix path "PSP_GAME/USRDIR/PRX" -> "PSP_GAME/USRDIR/MODULE".

- listing UCJS10100(v1.01) patch
also change to listing patch style.