### PR TITLE
fix dead links

### DIFF
--- a/docs/formats/models/mdl3_modelset3.md
+++ b/docs/formats/models/mdl3_modelset3.md
@@ -20,7 +20,7 @@ It is a rather structured, yet complex format.
 
 !!! warning
 
-    A lot of this may be outdated, refer to the [010 Editor templates](https://github.com/Nenkai/GT-File-Specifications-Documentation/tree/master/Formats/PS3/Models)
+    A lot of this may be outdated, refer to the [010 Editor templates](https://github.com/Nenkai/GT-File-Specifications-Documentation/tree/master/Formats/Shared/Models)
 
 
 ??? abstract "Structure (click to expand)"
@@ -126,7 +126,7 @@ Unknown                 |  `0x2E`        | `ushort`           | Unknown. Maybe f
 
     While PSP and PS3 GTs supports most opcodes, they also have their own (assigned with their unique opcode).
 
-    Refer to [PDTools.Files](https://github.com/Nenkai/PDTools/tree/master/PDTools.Files/Models/ModelSet3/Commands) for the commands.
+    Refer to [PDTools.Files](https://github.com/Nenkai/PDTools/tree/master/PDTools.Files/Models/PS3/PGLCommands) for the commands.
 
 ---
 

--- a/docs/ps3/models.md
+++ b/docs/ps3/models.md
@@ -14,7 +14,7 @@ comments: true
 
 GT5 does not have a tool to extract models from.
 
-GT6 meshes within models can be somewhat extracted using [this tool](https://forum.xentax.com/viewtopic.php?t=19919). However not all models are supported. 
+GT6 meshes within models can be somewhat extracted using [this id-deamon's tool](https://reshax.com/files/file/1138-gt6rar). However not all models are supported.
 
 ##### Creation
 

--- a/docs/ps3/models.md
+++ b/docs/ps3/models.md
@@ -14,7 +14,7 @@ comments: true
 
 GT5 does not have a tool to extract models from.
 
-GT6 meshes within models can be somewhat extracted using [this id-deamon's tool](https://reshax.com/files/file/1138-gt6rar). However not all models are supported.
+GT6 meshes within models can be somewhat extracted using [this id-daemon's tool](https://reshax.com/files/file/1138-gt6rar). However not all models are supported.
 
 ##### Creation
 

--- a/docs/ps4/tools.md
+++ b/docs/ps4/tools.md
@@ -8,4 +8,4 @@
 [vgmstream](https://dl.vgmstream.org/)| vgmstream | Tool for playback of various audio formats such as SGD/SGX used in GT5. (Mostly a foobar2000 plugin). |
 [GT.RText](https://github.com/Razer2015/GT.RText/releases)| xfileFIN, Nenkai | Tool to view and edit text/localization files (.rtext/.rt2) |
 [GTESDExtractor](https://github.com/AJB-Tech/GTESDExtractor/releases)| TheAdmiester | Quickly extract audio and RPM data from Gran Turismo Sport's GTESD file format. |
-[GTS/GT7 Model Extractor](https://forum.xentax.com/viewtopic.php?t=19088)| daemon1 | Meshes + Textures only |
+[GTS/GT7 Model Extractor](https://reshax.com/files/file/31-gran-turismo-sport-gran-turismo-7-ps4-model-tools/)| id-daemon1 | Meshes + Textures only |

--- a/docs/ps4/tools.md
+++ b/docs/ps4/tools.md
@@ -8,4 +8,4 @@
 [vgmstream](https://dl.vgmstream.org/)| vgmstream | Tool for playback of various audio formats such as SGD/SGX used in GT5. (Mostly a foobar2000 plugin). |
 [GT.RText](https://github.com/Razer2015/GT.RText/releases)| xfileFIN, Nenkai | Tool to view and edit text/localization files (.rtext/.rt2) |
 [GTESDExtractor](https://github.com/AJB-Tech/GTESDExtractor/releases)| TheAdmiester | Quickly extract audio and RPM data from Gran Turismo Sport's GTESD file format. |
-[GTS/GT7 Model Extractor](https://reshax.com/files/file/31-gran-turismo-sport-gran-turismo-7-ps4-model-tools/)| id-daemon1 | Meshes + Textures only |
+[GTS/GT7 Model Extractor](https://reshax.com/files/file/31-gran-turismo-sport-gran-turismo-7-ps4-model-tools/)| id-daemon | Meshes + Textures only |


### PR DESCRIPTION
some gt6 and gt7 links dead.
1. XeNTaX links
Change to ResHax ones. Because XeNTax is closed.

1. GitHub links
These refactor seems to break GT Modding Hub links.



https://github.com/Nenkai/PDTools/commit/bc8ac68fa6e7e32985942d3942445121f5df0fd2
-> affect 010 editor link of `docs/formats/models/mdl3_modelset3.md` .

https://github.com/Nenkai/GT-File-Specifications-Documentation/commit/40d1cede1ecccef02daa65e53daacb4a60d6791d
-> affect command link of `docs/ps3/models.md` .